### PR TITLE
Implemented Axios request interceptor

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,23 @@
+### Testing TODO
+
+This document will grow along with the project. It will contain the testing plan, test cases, and in some cases, even the results.
+
+For now; this is more of a reminder to myself what tests I need to write once the project is more mature. The structure of this document may very well change in the future, as unit testing alone will not be enough, and I will need to include integration and possibly end-to-end testing as well.
+
+#### Axios Interceptor Testing
+
+These tests were performed to ensure that the Axios interceptor functions as expected. The interceptor is responsible for adding the user's JWT token to the headers of every request made to the server. It also checks for an expired access token and refreshes it if necessary.
+
+Request Interceptor:
+
+- [ ] Test that the request interceptor adds the JWT token to the auth headers of every request.
+- [ ] Test that the request interceptor does not add the JWT token to the auth headers of requests if no "session" is in progress, ie user is not logged in.
+- [ ] Test that the access token is refreshed if it is expired.
+- [ ] Test that the access token is not refreshed if it is not expired.
+
+Response Interceptor:
+Note: The response interceptor is not yet implemented. It will be responsible for checking the response status code and refreshing the access token if necessary.
+
+<p align="right">
+  <a href="#">Back to the top</a>
+</p>

--- a/frontend/api/axiosDefaults.tsx
+++ b/frontend/api/axiosDefaults.tsx
@@ -1,11 +1,13 @@
 import axios from 'axios';
 import { Platform } from 'react-native';
 
-const baseURL = Platform.OS === 'android' ? `${process.env.EXPO_PUBLIC_ANDROID_URL}` : `${process.env.EXPO_PUBLIC_LOCALHOST_URL}`;
+const baseURL =
+  Platform.OS === 'android'
+    ? `${process.env.EXPO_PUBLIC_ANDROID_URL}`
+    : `${process.env.EXPO_PUBLIC_LOCALHOST_URL}`;
 
 axios.defaults.baseURL = baseURL;
 axios.defaults.headers.post['content-type'] = 'multipart/form-data';
 axios.defaults.withCredentials = true;
 
-export const axiosRequest = axios.create();
-export const axiosResponse = axios.create();
+export const axiosInstance = axios.create();

--- a/frontend/contexts/AuthContext.tsx
+++ b/frontend/contexts/AuthContext.tsx
@@ -1,8 +1,8 @@
-import { createContext, useContext, useEffect, useMemo } from 'react';
-import { getStorageItemAsync, useStorageState } from '../hooks/useStorageState';
+import { createContext, useContext, useEffect } from 'react';
+import { useStorageState } from '../hooks/useStorageState';
 import axios from 'axios';
-import 'core-js/stable/atob'; // Required for atob to work in React Native
-import { axiosRequest } from '@/api/axiosDefaults';
+import { axiosInstance } from '@/api/axiosDefaults';
+import { tokenExpired } from '@/utils/dataUtils';
 
 const AuthContext = createContext<{
   signIn: (username: string, password: string) => Promise<void>;
@@ -29,70 +29,59 @@ export function useSession() {
 }
 
 export function SessionProvider(props: React.PropsWithChildren) {
-  console.log('SessionProvider');
   const [[isLoading, session], setSession] = useStorageState('session');
 
   useEffect(() => {
-    // Will refresh the access token with every axios request if the session exists
-    const requestInterceptor = axiosRequest.interceptors.request.use(
+    const requestInterceptor = axiosInstance.interceptors.request.use(
       async (config: any) => {
         if (session) {
-          config.headers.Authorization = `Bearer ${(session as { access?: string })?.access}`;
-          try {
-            console.log('trying request', config);
-            const { data } = await axios.post('token/refresh/', {
-              refresh: (session as { refresh?: string })?.refresh,
-            });
-            setSession({ ...session, access: data.access });
-            console.log('Session refreshed token:', data.access);
-          } catch (error) {
-            console.error('Failed to refresh token:', error);
-            setSession(null);
+          let accessToken = (session as { access?: string })?.access;
+
+          // Refresh the token if it is expired
+          if (accessToken && tokenExpired(accessToken)) {
+            try {
+              const { data } = await axios.post('token/refresh/', {
+                refresh: (session as { refresh?: string })?.refresh,
+              });
+
+              setSession({ ...session, access: data.access });
+              accessToken = data.access;
+              console.log('AxiosInterceptor - Refreshed session token:', data.access);
+            } catch (error) {
+              console.error('Failed to refresh token:', error);
+              setSession(null);
+            }
           }
+
+          // Finally set the access token in the Auth header
+          config.headers.Authorization = `Bearer ${accessToken}`;
         }
         return config;
       },
       (error) => Promise.reject(error),
     );
 
-    // NOTE: NEEDS WORK
-    // NOTE: This interceptor will only work for the first request after the session is set, needs more testing
-    const responseInterceptor = axiosRequest.interceptors.response.use(
+    // NOTE: Default response interceptor
+    const responseInterceptor = axiosInstance.interceptors.response.use(
       (response) => response,
       async (error) => {
-        // Set the original request config to a variable
-        const originalRequest = error.config;
-
-        if (error.response?.status === 401 && !originalRequest._retry && session) {
-          // Prevent infinite loop
-          originalRequest._retry = true;
-
-          try {
-            const { data } = await axios.post('token/refresh/', {
-              refresh: (session as { refresh?: string })?.refresh,
-            });
-            setSession({ ...session, access: data.access });
-            originalRequest.headers.Authorization = `Bearer ${data.access}`;
-            console.log('Axios request interceptor response, 401 error, token refreshed');
-
-            // Retry the original request
-            return axiosRequest(originalRequest);
-          } catch (error) {
-            console.error('Failed to refresh token:', error);
-            setSession(null);
-            return Promise.reject(error); // If future error handling is needed, best to reject the promise at this stage before checking for other error codes.
-          }
+        if (error.response) {
+          console.log(error.response.data);
+          console.log(error.response.status);
+          console.log(error.response.headers);
+        } else if (error.request) {
+          console.log(error.request);
         } else {
-          console.error('Interceptor response error:', error);
-          console.error('Interceptor response error.config:', error.config);
+          console.log('Error', error.message);
         }
+        console.log(error.config);
         return Promise.reject(error);
       },
     );
 
     return () => {
-      axiosRequest.interceptors.request.eject(requestInterceptor);
-      axiosRequest.interceptors.response.eject(responseInterceptor);
+      axiosInstance.interceptors.request.eject(requestInterceptor);
+      axiosInstance.interceptors.response.eject(responseInterceptor);
     };
   }, [session]);
 
@@ -117,8 +106,7 @@ export function SessionProvider(props: React.PropsWithChildren) {
         },
         session: session as { access: string; refresh: string } | null,
         isLoading,
-      }}
-    >
+      }}>
       {props.children}
     </AuthContext.Provider>
   );

--- a/frontend/utils/dataUtils.ts
+++ b/frontend/utils/dataUtils.ts
@@ -1,0 +1,24 @@
+import 'core-js/stable/atob'; // Required for atob to work in React Native
+import { jwtDecode } from 'jwt-decode';
+
+interface DecodedToken {
+  token_type: string;
+  exp: number;
+  iat: number;
+  jti: string;
+  user_id: number;
+  username: string;
+  profile_image: string;
+  is_staff: boolean;
+  is_superuser: boolean;
+  is_active: boolean;
+  id: number; // NOTE: Repeat of user_id
+}
+
+// This function checks if the "session" access token is expired
+export function tokenExpired(token: string): boolean {
+  const decodedToken = jwtDecode<DecodedToken>(token);
+  const tokenExpiration = decodedToken.exp;
+  const currentTime = Date.now() / 1000;
+  return tokenExpiration < currentTime;
+}


### PR DESCRIPTION
- Added a dataUtils file for helper functions; added "tokenExpired" helper function to check if a JWT access token is expired
- Request interceptor now checks if the access token is expired; and only if expired; attempts to refresh the access token. This is instead of its initial behaviour of refreshing every time.
- Replaced response interceptor with "Axios Interceptor" documentation defaults ([interceptors](https://axios-http.com/docs/interceptors) and [handling_errors](https://axios-http.com/docs/handling_errors))
- Added TESTING.md and added the current plans for the Axios instance created and used in the project.

PS. in the dataUtils file an interface for a decoded JWT was added, this currently covers all parameters of the JWT, and is meant for more of a reminder for future helper functions that will use the access token.